### PR TITLE
Adding Langchain example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Plus these scripts to demonstrate additional features:
 
 5. [`chat_safety.py`](./chat_safety.py): The simple script with exception handling for Azure AI Content Safety filter errors.
 6. [`chat_async.py`](./chat_async.py): Uses the async clients to make asynchronous calls, including an example of sending off multiple requests at once using `asyncio.gather`.
+6. [`chat_langchain.py`](./chat_langchain.py): Uses the langchain SDK to generate chat completions. [Learn more from Langchain docs](https://python.langchain.com/docs/get_started/quickstart)
 
 ## Setting up the environment
 
@@ -62,3 +63,5 @@ depending on the environment variables you set.
     OLLAMA_ENDPOINT=http://localhost:11434/v1
     OLLAMA_MODEL=llama2
     ```
+
+    If you're running inside the Dev Container, replace `localhost` with `host.docker.internal`.

--- a/chat_langchain.py
+++ b/chat_langchain.py
@@ -1,0 +1,39 @@
+import os
+
+import azure.identity
+from dotenv import load_dotenv
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import AzureChatOpenAI, ChatOpenAI
+
+# Setup the OpenAI client to use either Azure, OpenAI.com, or Ollama API
+load_dotenv(override=True)
+API_HOST = os.getenv("API_HOST")
+
+if API_HOST == "azure":
+    token_provider = azure.identity.get_bearer_token_provider(
+        azure.identity.DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+    )
+    llm = AzureChatOpenAI(
+        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+        azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT"),
+        openai_api_version=os.getenv("AZURE_OPENAI_VERSION"),
+        azure_ad_token_provider=token_provider,
+    )
+elif API_HOST == "ollama":
+    llm = ChatOpenAI(
+        model_name=os.getenv("OLLAMA_MODEL"),
+        openai_api_base=os.getenv("OLLAMA_ENDPOINT"),
+        openai_api_key=os.getenv("OPENAI_KEY"),
+    )
+else:
+    llm = ChatOpenAI(model_name=os.getenv("OPENAI_MODEL"), openai_api_key=os.getenv("OPENAI_KEY"))
+
+
+prompt = ChatPromptTemplate.from_messages(
+    [("system", "You are a helpful assistant that makes lots of cat references and uses emojis."), ("user", "{input}")]
+)
+chain = prompt | llm
+response = chain.invoke({"input": "write a haiku about a hungry cat that wants tuna"})
+
+print(f"Response from {API_HOST}: \n")
+print(response.content)


### PR DESCRIPTION
## Purpose

Fixes #2 (somewhat) by adding a Langchain example that shows how to switch between the three provider options and do a simple chat completion. I can potentially port the other examples in future to langchain as well if it is useful (or others can).

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Run example for each provider, azure, openai, ollama

![Screenshot 2024-03-25 at 4 12 30 PM](https://github.com/pamelafox/python-openai-demos/assets/297042/67be17cc-b3be-4d1a-8ca5-9e59a72df4a7)
